### PR TITLE
refcator: require style to be provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,16 +12,19 @@ You can currently:
 - define a zoom level
 - define a min and max zoom level
 - define if the map should be interactive
-- use your own style URL (defaults to a basic Open Street Maps raster tile)
+- use your own style URL or style specification
 - define coordinates which should display a marker
 
 ![Stimulus MapLibre hero image](/images/stimulus-maplibre-hero.png)
 
 ## Todo's
 
-- [ ] Remove default OSM style and require active provision of style URL? (see the [OSM policy](https://operations.osmfoundation.org/policies/tiles/))
+- [x] Remove default OSM style and require active provision of style URL? (see the [OSM policy](https://operations.osmfoundation.org/policies/tiles/))
 - [ ] figure out NPM publishing
 - [ ] enhance docs
+- [ ] setup GitHub Action for CI
+- [ ] improve error messages (more specific)
+- [ ] consider removing marker functionaloty as it may be too specific (this should really only handle the basics)
 
 ## Developing
 

--- a/index.html
+++ b/index.html
@@ -31,6 +31,8 @@
   <body>
     <div
       data-controller="maplibre"
+      data-maplibre-style-url-value=""
+      data-maplibre-style-specification-value='{"version":8,"sources":{"osm":{"type":"raster","tiles":["https://a.tile.openstreetmap.org/{z}/{x}/{y}.png"],"tileSize":256,"attribution":"&copy; OpenStreetMap Contributors","maxzoom":19}},"layers":[{"id":"osm","type":"raster","source":"osm"}]}'
       data-maplibre-center-value="13.404954,52.520008"
       data-maplibre-zoom-value="16"
       data-maplibre-marker-center-value="13.404954,52.520008"

--- a/specs/index.test.ts
+++ b/specs/index.test.ts
@@ -36,7 +36,7 @@ describe("stimulus-maplibre", () => {
     `;
 
     await waitFor(() => {
-      expect(console.error).toHaveBeenLastCalledWith(
+      expect(console.error).toHaveBeenCalledWith(
         "Please provide valid longitude and latitude values"
       );
     });
@@ -53,9 +53,24 @@ describe("stimulus-maplibre", () => {
     `;
 
     await waitFor(() => {
-      expect(console.error).toHaveBeenLastCalledWith(
+      expect(console.error).toHaveBeenCalledWith(
         "Please provide valid longitude and latitude values"
       );
+    });
+  });
+
+  test("errors without a style value (either style URL or style spec)", async () => {
+    document.body.innerHTML = `
+      <div
+        style="width: 500px; height: 500px;"
+        data-controller="maplibre"
+        data-maplibre-center-value="13.12345,52.12345"
+        data-maplibre-marker-center-value="13.12345,52.12345"
+      ></div>.
+    `;
+
+    await waitFor(() => {
+      expect(console.error).toHaveBeenCalledWith("No style value was provided");
     });
   });
 });


### PR DESCRIPTION
We don't want to fallback to the OpenStreetMap tiles which also have a usage policy.