### PR TITLE
refactor: require separate map container as Stimulus target

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,7 +34,8 @@
       data-maplibre-center-value="13.404954,52.520008"
       data-maplibre-zoom-value="16"
       data-maplibre-marker-center-value="13.404954,52.520008"
-      class="w-screen h-96"
-    ></div>
+    >
+      <div data-maplibre-target="mapContainer" class="w-screen h-96"></div>
+    </div>
   </body>
 </html>

--- a/specs/index.test.ts
+++ b/specs/index.test.ts
@@ -29,10 +29,14 @@ describe("stimulus-maplibre", () => {
   test("errors with invalid latitude or longitude for map", async () => {
     document.body.innerHTML = `
       <div
-        style="width: 500px; height: 500px;"
         data-controller="maplibre"
         data-maplibre-center-value="abc,52.12345"
-      ></div>.
+      >
+        <div
+          data-maplibre-target="mapContainer"
+          style="width: 500px; height: 500px;"
+        ></div>
+      </div>.
     `;
 
     await waitFor(() => {
@@ -45,11 +49,15 @@ describe("stimulus-maplibre", () => {
   test("errors with invalid latitude or longitude for marker", async () => {
     document.body.innerHTML = `
       <div
-        style="width: 500px; height: 500px;"
         data-controller="maplibre"
         data-maplibre-center-value="13.12345,52.12345"
         data-maplibre-marker-center-value="13.12345,abc"
-      ></div>.
+      >
+      <div
+        data-maplibre-target="mapContainer"
+        style="width: 500px; height: 500px;"
+      ></div>
+      </div>.
     `;
 
     await waitFor(() => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,14 +31,22 @@ export default class extends Controller {
     markerCenter: String,
   };
 
+  declare readonly hasMapContainerTarget: boolean;
+  declare readonly mapContainerTarget: HTMLElement;
+  declare readonly mapContainerTargets: HTMLElement[];
+
+  static targets = ["mapContainer"];
+
   connect(): void {
-    this.checkContainerDimensions();
+    const hasValidMapContainer = this.mapContainerTargetIsValid();
+    const hasValidMapContainerSize = this.mapContainerTargetHasValidSize();
     const hasValidCenter = this.isValidCenterString(this.centerValue);
 
-    if (!hasValidCenter) return;
+    if (!hasValidMapContainer || !hasValidMapContainerSize || !hasValidCenter)
+      return;
 
     this.map = new maplibregl.Map({
-      container: this.element as HTMLElement,
+      container: this.mapContainerTarget,
       style: this.mapStyle,
       center: [this.longitude, this.latitude],
       zoom: this.zoomValue,
@@ -112,11 +120,34 @@ export default class extends Controller {
     }
   }
 
-  checkContainerDimensions(): void {
-    if (this.element.clientWidth === 0 || this.element.clientHeight === 0) {
-      console.warn(
-        "The map is not visible because either the map container's height or width is zero."
+  mapContainerTargetHasValidSize(): boolean {
+    if (
+      this.mapContainerTarget.clientWidth === 0 ||
+      this.mapContainerTarget.clientHeight === 0
+    ) {
+      console.error(
+        "The map was not rendered because either the map container's height or width is zero."
       );
+      return false;
+    } else {
+      return true;
+    }
+  }
+
+  mapContainerTargetIsValid(): boolean {
+    switch (true) {
+      case !this.hasMapContainerTarget:
+        console.error(
+          `No map container was found. Please add an element with the property data-maplibre-target="mapContainer".`
+        );
+        return false;
+      case this.mapContainerTargets.length > 1:
+        console.error(
+          `Multiple map containers were found. Please define only one element with the property data-maplibre-target="mapContainer".`
+        );
+        return false;
+      default:
+        return true;
     }
   }
 


### PR DESCRIPTION
BREAKING CHANGE: We do not use this.element anymore to append the map. Instead we require an explicit HTML element as a Stimulus target.